### PR TITLE
35 pages in back

### DIFF
--- a/client/src/components/search_page_components/filter/Filter.jsx
+++ b/client/src/components/search_page_components/filter/Filter.jsx
@@ -3,13 +3,7 @@ import PropTypes from "prop-types";
 import "./Filter.css";
 import Patoune from "../../../assets/logo/1patounes.png";
 
-function Filter({
-  onFilterChange,
-  setSearch,
-  setCountPage,
-  setPageLim,
-  setPageLimSup,
-}) {
+function Filter({ onFilterChange, setSearch, setCountPage, setOffset }) {
   const [postalCode, setPostalCode] = useState("");
   const [animal, setAnimal] = useState("tous");
   const [structureType, setStructureType] = useState("tous");
@@ -26,8 +20,7 @@ function Filter({
     };
     onFilterChange(filters);
     setCountPage(1);
-    setPageLim(0);
-    setPageLimSup(30);
+    setOffset(0);
   };
 
   // Handle Input Key Down if the key Enter it press, it send Input and filter values to parent component
@@ -122,8 +115,7 @@ Filter.propTypes = {
   onFilterChange: PropTypes.func.isRequired,
   setSearch: PropTypes.func.isRequired,
   setCountPage: PropTypes.func.isRequired,
-  setPageLim: PropTypes.func.isRequired,
-  setPageLimSup: PropTypes.func.isRequired,
+  setOffset: PropTypes.func.isRequired,
 };
 
 export default Filter;

--- a/client/src/pages/search_page/SearchPage.jsx
+++ b/client/src/pages/search_page/SearchPage.jsx
@@ -13,28 +13,30 @@ function SearchPage() {
   const [filters, setFilters] = useState({});
   const [filteredStructures, setFilteredStructures] = useState(allStructures);
   const [search, setSearch] = useState("");
-  const [pageLim, setPageLim] = useState(0);
-  const [pageLimSup, setPageLimSup] = useState(30);
+  const [limit] = useState(30);
+  const [offset, setOffset] = useState(0);
   const [countPage, setCountPage] = useState(1);
+  const [reponseNumber, setReponseNumber] = useState();
   const URL = import.meta.env.VITE_API_URL;
-
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await fetch(`${URL}/homestructure?q=${search}`);
+        const response = await fetch(
+          `${URL}/homestructure?search=${search}&limit=${limit}&offset=${offset}`
+        );
         if (!response.ok === true) {
           throw new Error("Erreur lors de la récupération des données.");
         }
         const jsonData = await response.json();
-        setAllStructures(jsonData);
+        setAllStructures(jsonData.result);
+        setReponseNumber(jsonData.totalRow.total);
       } catch (error) {
         notify("Erreur de réseau. Veuillez vérifier votre connexion.", "error");
         console.error("Fetch error:", error);
       }
     };
     fetchData();
-  }, [search, URL]);
-
+  }, [search, URL, offset, limit]);
   useEffect(() => {
     const applyFilters = () => {
       // Start with all structures
@@ -99,16 +101,13 @@ function SearchPage() {
     // Update the filters state with the new filters
     setFilters(newFilters);
   };
-
+  // button for next and prev page
   const next = () => {
-    setPageLim(pageLim + 30);
-    setPageLimSup(pageLimSup + 30);
+    setOffset(offset + limit);
     setCountPage(countPage + 1);
   };
-
   const prev = () => {
-    setPageLim(pageLim - 30);
-    setPageLimSup(pageLimSup - 30);
+    setOffset(offset - limit);
     setCountPage(countPage - 1);
   };
 
@@ -119,14 +118,13 @@ function SearchPage() {
         onFilterChange={handleFilterChange}
         setSearch={setSearch}
         setCountPage={setCountPage}
-        setPageLim={setPageLim}
-        setPageLimSup={setPageLimSup}
+        setOffset={setOffset}
       />
       {allStructures.length < 1 && search.length < 1 ? (
         <p className="loading">Chargement ...</p>
       ) : (
         <ul id="peopleMap">
-          {filteredStructures.slice(pageLim, pageLimSup).map((structure) => (
+          {filteredStructures.map((structure) => (
             <li key={structure.id} id="peopleList">
               <Link to={`/reservation/${structure.id}`}>
                 <HomeStructureList structure={structure} />
@@ -149,13 +147,13 @@ function SearchPage() {
         </button>
 
         <p
-          hidden={Math.ceil(filteredStructures.length / 30) <= 1}
-        >{`page ${countPage} sur ${Math.ceil(filteredStructures.length / 30)}`}</p>
+          hidden={Math.ceil(reponseNumber / limit) <= 1}
+        >{`page ${countPage} sur ${Math.ceil(reponseNumber / limit)}`}</p>
 
         <button
           type="button"
           onClick={next}
-          hidden={pageLimSup >= filteredStructures.length}
+          hidden={reponseNumber <= limit}
           className="buttonNextPrev"
         >
           <img className="buttonImg" src={BtnNext} alt="bouton suivant" />

--- a/server/app/controllers/home_structureActions.js
+++ b/server/app/controllers/home_structureActions.js
@@ -3,17 +3,25 @@ const tables = require("../../database/tables");
 
 // The B of BREAD - Browse (Read All) operation
 const browse = async (req, res, next) => {
+  const { search } = req.query;
+  const { limit } = req.query;
+  const { offset } = req.query;
   try {
-    if (req.query.q != null) {
-      // Fetch home_structure whose includes the search Bar words
-      const homeStructure = await tables.home_structure.includes(req.query.q);
-      res.status(200).json(homeStructure);
-    } else {
-      // Fetch all home_structure from the database
-      const homeStructure = await tables.home_structure.readAll();
-      // Respond with the home_structure in JSON format
-      res.status(200).json(homeStructure);
-    }
+    // if (req.query.q != null) {
+    // Fetch home_structure whose includes the search Bar words
+    const homeStructure = await tables.home_structure.research(
+      search,
+      limit,
+      offset
+    );
+    res.status(200).json(homeStructure);
+    // }
+    // else {
+    //   // Fetch all home_structure from the database
+    //   const homeStructure = await tables.home_structure.readAll();
+    //   // Respond with the home_structure in JSON format
+    //   res.status(200).json(homeStructure);
+    // }
   } catch (err) {
     // Pass any errors to the error-handling middleware
     next(err);

--- a/server/app/controllers/home_structureActions.js
+++ b/server/app/controllers/home_structureActions.js
@@ -7,21 +7,12 @@ const browse = async (req, res, next) => {
   const { limit } = req.query;
   const { offset } = req.query;
   try {
-    // if (req.query.q != null) {
-    // Fetch home_structure whose includes the search Bar words
     const homeStructure = await tables.home_structure.research(
       search,
       limit,
       offset
     );
     res.status(200).json(homeStructure);
-    // }
-    // else {
-    //   // Fetch all home_structure from the database
-    //   const homeStructure = await tables.home_structure.readAll();
-    //   // Respond with the home_structure in JSON format
-    //   res.status(200).json(homeStructure);
-    // }
   } catch (err) {
     // Pass any errors to the error-handling middleware
     next(err);

--- a/server/database/fixtures/HomeStructureSeeder.js
+++ b/server/database/fixtures/HomeStructureSeeder.js
@@ -6,10 +6,10 @@ class HomeStructureSeeder extends AbstractSeeder {
   }
 
   run() {
-    for (let i = 0; i < 10; i += 1) {
+    for (let i = 0; i < 1000; i += 1) {
       // Generate fake user data
       const fakeHomeStructure = {
-        name: this.faker.internet.userName(),
+        name: this.faker.internet.userName(20),
         lastname: this.faker.person.lastName(),
         firstname: this.faker.person.firstName(),
         phone_number: this.faker.string.numeric(10),

--- a/server/database/models/HomeStructureRepository.js
+++ b/server/database/models/HomeStructureRepository.js
@@ -100,12 +100,13 @@ class HomeStructureRepository extends AbstractRepository {
     return result.affectedRows;
   }
 
-  // research for the searchBar
+  // research for the searchBar limits the number of results and returns the results from the offset
   async research(search, limit, offset) {
     const [result] = await this.database.query(
       `SELECT id, name, phone_number, location, postal_code, is_professional, cat, dog, price FROM ${this.table} WHERE name like ? OR location like ? LIMIT ${limit} OFFSET ${offset}`,
       [`%${search}%`, `%${search}%`]
     );
+    // count number of total rows
     const [count] = await this.database.query(
       `SELECT COUNT(id) AS total FROM ${this.table} WHERE name like ? OR location like ? `,
       [`%${search}%`, `%${search}%`]

--- a/server/database/models/HomeStructureRepository.js
+++ b/server/database/models/HomeStructureRepository.js
@@ -100,14 +100,18 @@ class HomeStructureRepository extends AbstractRepository {
     return result.affectedRows;
   }
 
-  // includes for the searchBar
-  async includes(search) {
+  // research for the searchBar
+  async research(search, limit, offset) {
     const [result] = await this.database.query(
-      `SELECT id, name, phone_number, location, postal_code, is_professional, cat, dog, price FROM ${this.table} WHERE name like ? OR location like ?`,
+      `SELECT id, name, phone_number, location, postal_code, is_professional, cat, dog, price FROM ${this.table} WHERE name like ? OR location like ? LIMIT ${limit} OFFSET ${offset}`,
       [`%${search}%`, `%${search}%`]
     );
-
-    return result;
+    const [count] = await this.database.query(
+      `SELECT COUNT(id) AS total FROM ${this.table} WHERE name like ? OR location like ? `,
+      [`%${search}%`, `%${search}%`]
+    );
+    const totalRow = count[0];
+    return { result, totalRow };
   }
 
   async login(homeStructure) {


### PR DESCRIPTION
## Description de l'Issue

Mettre la pagination dans le back afin d'éviter de requêter inutilement un trop grand nombre de résultats.

en lien avec l'US 19 (search bar)


## Tâches à réaliser

- [x] renommer .includes dans HomeStructureRepository.
- [x] limiter le nombre de résultats de la requête SQL et afficher le nombre total de résultats.
- [x] pouvoir naviguer de pages en pages



